### PR TITLE
Fix clear_entropy infinite loop

### DIFF
--- a/drbg.c
+++ b/drbg.c
@@ -645,11 +645,14 @@ drbg_error drbg_generate_with_user_entropy(drbg_ctx *ctx,
 /* DRBG uninstantiate */
 drbg_error drbg_uninstantiate(drbg_ctx *ctx)
 {
+
+    drbg_error ret = DRBG_OK;
+
 	if(drbg_check_instantiated(ctx)){
-		/* NOTE: we ignore the return value on purpose to clean up
-		 * the other fields in any case
+		/* NOTE: do not return immediately if an error happened,
+		 * empty the other fields first.
 		 */
-		ctx->methods->uninstantiate(ctx);
+		ret = ctx->methods->uninstantiate(ctx);
 	}
 
 	ctx->prediction_resistance = false;
@@ -659,5 +662,5 @@ drbg_error drbg_uninstantiate(drbg_ctx *ctx)
 
 	ctx->magic = 0;
 
-	return DRBG_OK;
+	return ret;
 }

--- a/drbg.c
+++ b/drbg.c
@@ -400,7 +400,6 @@ err:
 	if(entropy_pool != NULL){
 		if(clear_entropy_input(entropy_pool)){
 			ret = DRBG_ENTROPY_ERROR;
-			goto err;
 		}
 	}
 

--- a/drbg.c
+++ b/drbg.c
@@ -332,13 +332,11 @@ err:
 	if(entropy_pool1 != NULL){
 		if(clear_entropy_input(entropy_pool1)){
 			ret = DRBG_ENTROPY_ERROR;
-			goto err;
 		}
 	}
 	if(entropy_pool2 != NULL){
 		if(clear_entropy_input(entropy_pool2)){
 			ret = DRBG_ENTROPY_ERROR;
-			goto err;
 		}
 	}
 

--- a/entropy.c
+++ b/entropy.c
@@ -196,6 +196,11 @@ int clear_entropy_input(uint8_t *buf)
 	/* Clean the buffer until pos */
 	memset(curr_entropy_pool.entropy_buff, 0, curr_entropy_pool.entropy_buff_pos);
 
+	/* Ensure the pool is in an uninit state,
+	 * so it is fully reset by the next get_entropy_input call
+	 */
+	curr_entropy_pool_init = false;
+
 	ret = 0;
 err:
 	return ret;


### PR DESCRIPTION
This PR fixes a bug when instantiating repeatedly a DRBG, below is an example on how to trigger the bug with the current master branch, using the test entropy source flag at compile time.

```c
#define ASKED_STRENGTH 256
#define DST_LEN 32

int main()
{
		drbg_ctx drbg;

		for (int i = 0; i < 100; i++) {
			// printf("Starting iteration %i\n", i);
			const unsigned char pers_string[] = "DRBG_PERS";
			uint32_t asked_strength = ASKED_STRENGTH;

			drbg_error ret =
					drbg_instantiate(&drbg, pers_string, sizeof(pers_string) - 1, &asked_strength, true, DRBG_CTR, NULL);

			if (ret != DRBG_OK) {
				printf("Failed instantiation %i with error %i\n", i, ret);
				continue;
			}

			// Necessary call to trigger the bug
			uint8_t dst[DST_LEN];
			drbg_generate(&drbg, NULL, 0, dst, DST_LEN, true);

			drbg_uninstantiate(&drbg);
		}

	return 0;
}
```

The bug is a combination of a logic bug in the DRBG interface, and of an improper uninitialization of the entropy pool in the test entropy source.

The test entropy source is improperly uninitialized with clear_entropy(), with the current position of the cursor pool not being reset. This eventually leads to the clear_entropy() function failing its sanity check and returning an error code.

The error code triggers a goto instruction in _drbg_instantiate(), as is the common pattern throughout the codebase, but in this case, the goto instruction happens after the label. This causes an infinite loop. Removing the goto instruction avoids the infinite loop, and does not prevent further entropy clearing.

Additionally, I made it so the drbg_uninstantiate() function returns an error code if needed, while still enforcing proper uninitialization (prior to that, it always returned DRBG_OK).

The PR may need to be formated to your own code style. I am not used to PRs from a fork, so I am eager to receive any feedback.